### PR TITLE
support integrated servers

### DIFF
--- a/src/main/java/net/nullspace_mc/cutefulcake/mixin/core/MinecraftServerMixin.java
+++ b/src/main/java/net/nullspace_mc/cutefulcake/mixin/core/MinecraftServerMixin.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MinecraftServerMixin {
 
     // in case another mod changes level name during runtime ofc
-    @Inject(method = "setLevelName", at = @At("TAIL"))
-    private void whenLevelNameIsDefined(String levelName, CallbackInfo ci) {
+    @Inject(method = "setupWorld(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/level/LevelGeneratorType;Ljava/lang/String;)V", at = @At("HEAD"))
+    private void onSetupWorld(CallbackInfo ci) {
         CutefulCake.initializeCakeServer();
     }
 

--- a/src/main/resources/cutefulcake.mixins.json
+++ b/src/main/resources/cutefulcake.mixins.json
@@ -4,8 +4,6 @@
   "package": "net.nullspace_mc.cutefulcake.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-  ],
-  "server": [
     "core.CommandManagerMixin",
     "core.MinecraftServerMixin",
     "core.PlayerListHeaderS2CPacketMixin",
@@ -16,6 +14,8 @@
     "feature.emeraldOreUpdateSuppressor.OreBlockMixin",
     "counter.HopperBlockEntityMixin",
     "tick.MinecraftServerMixin"
+  ],
+  "server": [
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Moves the registered mixins to the `mixin` array so they get injected client-side, and changes the settings initializer injection to `setupWorld` (the equivalent method fabric-carpet injects into) so it doesn't crash with integrated servers.